### PR TITLE
Revert "chore(deps): update helm release kube-prometheus-stack to v45.28.1"

### DIFF
--- a/deploy/kube-prometheus-stack/base/kustomization.yaml
+++ b/deploy/kube-prometheus-stack/base/kustomization.yaml
@@ -24,7 +24,7 @@ helmCharts:
   - name: kube-prometheus-stack
     releaseName: kube-prometheus-stack
     namespace: monitoring
-    version: 45.28.1
+    version: 45.28.0
     valuesFile: values.yaml
     includeCRDs: true
     repo: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Reverts acend/infrastructure#193

Seems buggy https://github.com/prometheus-community/helm-charts/issues/3396