### PR TITLE
increase max-pods to 150 and increase descheduler to 95%

### DIFF
--- a/deploy/descheduler/base/values.yaml
+++ b/deploy/descheduler/base/values.yaml
@@ -13,7 +13,7 @@ deschedulerPolicy:
         - name: HighNodeUtilization
           args:
             thresholds:
-              pods:   90
+              pods:   95
       plugins:
         balance:
           enabled:

--- a/deploy/descheduler/base/values.yaml
+++ b/deploy/descheduler/base/values.yaml
@@ -7,6 +7,7 @@ deschedulerPolicy:
       pluginConfig:
         - name: DefaultEvictor
           args:
+            ignorePvcPods: true
             evictLocalStoragePods: true
         - name: RemoveDuplicates
         - name: RemovePodsViolatingInterPodAntiAffinity

--- a/terraform/modules/rke2-cluster/templates/cloudinit-worker.yaml
+++ b/terraform/modules/rke2-cluster/templates/cloudinit-worker.yaml
@@ -19,6 +19,8 @@ write_files:
     server: https://${lb_address}:9345
     token: ${rke2_cluster_secret}
     cloud-provider-name: external
+    kubelet-arg:
+    - "max-pods=150"
 - path: /opt/rke2/run_rke2.sh
   permissions: "0755"
   owner: root:root


### PR DESCRIPTION
Our pod in the worker nodes are like:
0: 100
1:  77
2: 105

The descheduler is moving the pods all the time between the nodes which causes several restarts. Increase move rate from 90% to 95%. Main cause are the amount of PRs which creating pods all the time.

RKE config:
https://www.suse.com/de-de/support/kb/doc/?id=000021093
